### PR TITLE
Fix dockerfile and docker compose build issues

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,10 +14,13 @@ OPENAI_MAX_PARALLEL_REQUESTS=8
 REDIS_URL=redis://redis:6379
 REDIS_TTL_DAYS=7
 REDIS_JOBS_PREFIX=jobs
+REDIS_PORT=6379
+REDIS_MAX_MEMORY=512mb
 
 # File Processing Configuration
 TEMP_DIR=/tmp/media-to-text
 CLEANUP_TEMP_FILES=true
+DATA_DIR=./data
 
 # FFmpeg Configuration
 FFMPEG_CONTAINER_URL=http://ffmpeg:8080
@@ -25,11 +28,17 @@ FFMPEG_CONTAINER_URL=http://ffmpeg:8080
 # Monitoring Configuration
 ENABLE_METRICS=true
 METRICS_PORT=9090
+PROMETHEUS_PORT=9091
+GRAFANA_PORT=3000
+GRAFANA_PASSWORD=admin
 
 # Logging Configuration
 LOG_LEVEL=INFO
 ENABLE_STRUCTURED_LOGGING=true
 ENABLE_AXIOM=false
-AXIOM_TOKEN=your_axiom_token_here
+AXIOM_TOKEN=
 AXIOM_DATASET=media-to-text-logs
 LOG_SENSITIVE_DATA=false
+
+# System Configuration
+TZ=UTC

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,8 +36,8 @@ dev = [
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
-[tool.setuptools]
-packages = ["media_to_text"]
+[tool.hatch.build.targets.wheel]
+packages = ["src/media_to_text"]
 
 [tool.black]
 line-length = 88


### PR DESCRIPTION
The Docker build failed with an `OSError: Readme file does not exist: README.md` because `pyproject.toml` referenced `README.md`, but the file was not available in the build context.

To resolve the issue:
*   `README.md` was removed from `.dockerignore` to ensure it is included in the Docker build context.
*   `COPY README.md ./` was added to `Dockerfile` before the `uv sync` command, making the file available for the Python build process.
*   A `production` stage (`FROM base as production`) was added to `Dockerfile` to support the `target: production` reference in `docker-compose.yml`, enabling a proper multi-stage build.

These modifications ensure all required files are present during the build and the Docker Compose target is correctly defined, allowing the image to build successfully.